### PR TITLE
Show the gust direction of last year instead of the one of today 

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -463,7 +463,7 @@
               </tr>
               <tr>
                 <td>High Wind</td>
-                <td>$days_ago($days_ago=$n).wind.max $day.wind.gustdir</td>
+                <td>$days_ago($days_ago=$n).wind.max $days_ago($days_ago=$n).wind.gustdir</td>
                 <td>$days_ago($days_ago=$n).wind.maxtime</td>
               </tr>
               <tr>


### PR DESCRIPTION
in the history view. There was a typo that is fixed in this pull request.